### PR TITLE
Allow dash (-) in aliases

### DIFF
--- a/sleepy/lexer.py
+++ b/sleepy/lexer.py
@@ -140,7 +140,7 @@ def t_IMPORT_PATH(t):
 
 # Matches IDs and keywords
 def t_ID(t):
-    r'[a-zA-Z_][a-zA-Z_0-9]*'
+    r'[a-zA-Z_][a-zA-Z_0-9\-]*'
     t.type = keywords.get(t.value,'ID')
     return t
 


### PR DESCRIPTION
When a dash (-) is present in an alias, the parser fails. 

Example:

```
alias CVE-2022-26923 {
    #code
}
```

I added a dash to the `t_ID` regular expression, after which the CNA is successfully parsed. This was a quick fix on my end and I don't have much knowledge of lexers. Thus, I'm not sure if this will cause other things to break.