### PR TITLE
Add fallback for missing semicolon in AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This change should not cause any issues.
 One issue that was encountered when developing Sleepy is that the parser in the official Sleep distribution does not conform to its corresponding documentation.
 Namely, it allows for missing semicolons after statements and missing commas between list items.
 Sleepy's parser will warn the user of these syntax errors, recover, and then continue parsing.
+The resultant abstract syntax tree will have nodes set to `None` where these syntax errors occurred.
+Sleepy's preprocessor may be used to fix some of these syntax errors before lexing or parsing occurs.
 
 This project is released under an MIT license.
 The unit tests are included from the [official Sleep distribution](http://sleep.dashnine.org/download.html) which is released under a [BSD-3 license](https://github.com/rsmudge/sleep/blob/master/license.txt) and copyrighted to [Raphael Mudge](https://github.com/rsmudge/sleep/tree/master).

--- a/examples/repair.py
+++ b/examples/repair.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Repairs the following script issues which are not allowed by sleepy
+# but are allowed by the parser in the official Sleep distribution:
+# - Adds missing semicolons before a script block's close (e.g '}')
+
+import sys
+from sleepy.lexer import *
+
+if len(sys.argv) > 1:
+    path = sys.argv[1]
+    with open(path, 'r') as file:
+        print(preprocess(file.read(), repair_missing_semicolons=True))
+else:
+    print('{} <path>'.format(sys.argv[0]))

--- a/sleepy/lexer.py
+++ b/sleepy/lexer.py
@@ -260,3 +260,24 @@ class SleepLexer(object):
             return next(self.token_stream)
         except StopIteration:
             return None
+
+# Functions
+
+def preprocess(script, repair_missing_semicolons=True):
+    repairedScript = []
+    lexer = SleepLexer()
+    lexer.input(script)
+    previousToken = None
+    for token in lexer:
+        if token.type == 'EOF':
+            break
+        if previousToken:
+            repairedScript.append(script[previousToken.lexpos:token.lexpos])
+        if repair_missing_semicolons and token and token.type == '}' and previousToken and previousToken.type not in (';', '{', '}'):
+            repairedScript[-1] = repairedScript[-1].replace(previousToken.value, previousToken.value + ';')
+        previousToken = token
+    if previousToken:
+        repairedScript.append(script[previousToken.lexpos:])
+        if previousToken.type not in (';', '{', '}'):
+            repairedScript.append(';')
+    return ''.join(repairedScript)

--- a/sleepy/parser.py
+++ b/sleepy/parser.py
@@ -823,20 +823,6 @@ class SleepParser(object):
     def parse(self, code, tracking=False):
         global parser
         script = parser.parse(code, tracking=tracking)
-        if script and not self.__has_dropped_nodes(script):
-            return script
-
-        repaired_code = self.__repair_missing_semicolons(code)
-        if repaired_code != code:
-            repaired_script = parser.parse(repaired_code, tracking=tracking)
-            if repaired_script:
-                script = repaired_script
-                if not self.__has_dropped_nodes(repaired_script):
-                    return repaired_script
-
-    def parse(self, code, tracking=False):
-        global parser
-        script = parser.parse(code, tracking=tracking)
         # Some sleep scripts are published with syntax errors because
         # the sleep interpreter that ships with Cobalt Strike does not
         # fully conform to the specification for the language. Namely,


### PR DESCRIPTION
The CobaltStrike sleep parser seems more relaxed when it comes to nodes not ending with a `;`  
This PR adds a fallback for such cases.  

For example, previously this was parsed to `None`:  

```
alias myalias {
	inline(&sub_function)
}
```  

After this PR, it becomes a regular `Call` statement.  