### PR TITLE
Fix preprocess function for missing semicolons in the token text case

### DIFF
--- a/sleepy/lexer.py
+++ b/sleepy/lexer.py
@@ -274,7 +274,10 @@ def preprocess(script, repair_missing_semicolons=True):
         if previousToken:
             repairedScript.append(script[previousToken.lexpos:token.lexpos])
         if repair_missing_semicolons and token and token.type == '}' and previousToken and previousToken.type not in (';', '{', '}'):
-            repairedScript[-1] = repairedScript[-1].replace(previousToken.value, previousToken.value + ';')
+            # Insert semicolon by position before the closing brace.
+            # Do not replace token text, because token values for quoted strings/literals are unquoted
+            # and text replacement can corrupt literal content.
+            repairedScript.append(';')
         previousToken = token
     if previousToken:
         repairedScript.append(script[previousToken.lexpos:])


### PR DESCRIPTION
The preprocess function turned  

```
 $a = 'ok'
```  
  into
```
  $a = 'ok;'
```  
When the CNA script contained a alias definition like:  
```
alias a {
    $a = 'ok'
  }
```
for example.
